### PR TITLE
CTR Prediction 모델 개발

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,35 @@
+model:
+  LGBM:
+    objective: "binary"
+    metric: "binary_logloss"
+    boosting_type: "gbdt"
+    learning_rate: 0.05
+    num_leaves: 31
+    max_depth: -1
+    min_data_in_leaf: 20
+    feature_fraction: 0.8
+    bagging_fraction: 0.8
+    bagging_freq: 5
+    verbose: -1
+    seed: 42
+    num_boost_round: 1000
+    early_stopping_rounds: 50
+  DeepFM:
+    embedding_dim: 8
+    deep_dims: [128, 64]
+    dropout: 0.3
+  DCNv2:
+    embedding_dim: 8
+    deep_dims: [128, 64]
+    cross_layers: 3
+    dropout: 0.3
+
+training:
+  batch_size: 256
+  epochs: 10
+  learning_rate: 0.001
+  random_seed: 42
+
+data:
+  dataset_path: "./data/day_0_sample_10000"
+  test_split: 0.2

--- a/configs/data.yaml
+++ b/configs/data.yaml
@@ -1,0 +1,3 @@
+data:
+  dataset_path: "./data/day_0_sample_10000"
+  test_split: 0.2

--- a/configs/dcn_v2.yaml
+++ b/configs/dcn_v2.yaml
@@ -1,0 +1,12 @@
+model:
+  DCNv2:
+    embedding_dim: 8
+    deep_dims: [128, 64]
+    cross_layers: 3
+    dropout: 0.3
+
+training:
+  batch_size: 256
+  epochs: 10
+  learning_rate: 0.001
+  random_seed: 42

--- a/configs/deepfm.yaml
+++ b/configs/deepfm.yaml
@@ -1,0 +1,11 @@
+model:
+  DeepFM:
+    embedding_dim: 8
+    deep_dims: [128, 64]
+    dropout: 0.3
+
+training:
+  batch_size: 256
+  epochs: 10
+  learning_rate: 0.001
+  random_seed: 42

--- a/configs/lgbm.yaml
+++ b/configs/lgbm.yaml
@@ -14,22 +14,9 @@ model:
     seed: 42
     num_boost_round: 1000
     early_stopping_rounds: 50
-  DeepFM:
-    embedding_dim: 8
-    deep_dims: [128, 64]
-    dropout: 0.3
-  DCNv2:
-    embedding_dim: 8
-    deep_dims: [128, 64]
-    cross_layers: 3
-    dropout: 0.3
 
 training:
   batch_size: 256
   epochs: 10
   learning_rate: 0.001
   random_seed: 42
-
-data:
-  dataset_path: "./data/day_0_sample_10000"
-  test_split: 0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ pandas = "1.5.3"
 scipy = "1.9.3"
 torch = "1.13.1"
 scikit-learn = "1.2.2"
+lightgbm = "4.5.0"
+pyyaml = "6.0.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+from . import datasets
+from . import layers
+from . import models
+from . import preprocessing
+from . import trainers
+from . import utils

--- a/src/datasets/__init__py
+++ b/src/datasets/__init__py
@@ -1,0 +1,3 @@
+from .criteo import CriteoDataset
+
+__all__ = ["CriteoDataset"]

--- a/src/datasets/criteo.py
+++ b/src/datasets/criteo.py
@@ -1,0 +1,16 @@
+import torch
+from torch.utils.data import Dataset, DataLoader
+
+
+# PyTorch Dataset
+class CriteoDataset(Dataset):
+    def __init__(self, numeric_data, categorical_data, labels):
+        self.numeric_data = torch.tensor(numeric_data.values, dtype=torch.float32)
+        self.categorical_data = torch.tensor(categorical_data.values, dtype=torch.long)
+        self.labels = torch.tensor(labels.values, dtype=torch.float32)
+
+    def __len__(self):
+        return len(self.labels)
+
+    def __getitem__(self, idx):
+        return self.numeric_data[idx], self.categorical_data[idx], self.labels[idx]

--- a/src/datasets/criteo.py
+++ b/src/datasets/criteo.py
@@ -2,15 +2,41 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 
 
-# PyTorch Dataset
 class CriteoDataset(Dataset):
+    """
+    A PyTorch Dataset for the Criteo dataset.
+    """
+
     def __init__(self, numeric_data, categorical_data, labels):
+        """
+        Initialize the CriteoDataset.
+
+        Parameters:
+            numeric_data (pd.DataFrame): A DataFrame containing numeric features.
+            categorical_data (pd.DataFrame): A DataFrame containing categorical features.
+            labels (pd.Series): A Series containing the target labels.
+        """
         self.numeric_data = torch.tensor(numeric_data.values, dtype=torch.float32)
         self.categorical_data = torch.tensor(categorical_data.values, dtype=torch.long)
         self.labels = torch.tensor(labels.values, dtype=torch.float32)
 
     def __len__(self):
+        """
+        Return the number of samples in the dataset.
+
+        Returns:
+            int: The number of samples.
+        """
         return len(self.labels)
 
     def __getitem__(self, idx):
+        """
+        Retrieve a single sample from the dataset.
+
+        Parameters:
+            idx (int): The index of the sample to retrieve.
+
+        Returns:
+            tuple: A tuple containing numeric features, categorical features, and the label.
+        """
         return self.numeric_data[idx], self.categorical_data[idx], self.labels[idx]

--- a/src/layers/__init__.py
+++ b/src/layers/__init__.py
@@ -1,0 +1,5 @@
+from .embedding_layer import EmbeddingLayer
+from .dense_layer import DenseLayer
+from src.layers.interaction_layer import FMInteractionLayer, CrossInteractionLayer
+
+__all__ = ["EmbeddingLayer", "DenseLayer", "FMInteractionLayer", "FMInteractionLayer"]

--- a/src/layers/dense_layer.py
+++ b/src/layers/dense_layer.py
@@ -1,0 +1,11 @@
+import torch.nn as nn
+
+
+class DenseLayer(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout=0.2):
+        super(DenseLayer, self).__init__()
+        layers = [nn.Linear(in_dim, out_dim), nn.ReLU(), nn.Dropout(dropout)]
+        self.fc = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.fc(x)

--- a/src/layers/dense_layer.py
+++ b/src/layers/dense_layer.py
@@ -2,10 +2,31 @@ import torch.nn as nn
 
 
 class DenseLayer(nn.Module):
+    """
+    A fully connected (dense) layer.
+    """
+
     def __init__(self, in_dim, out_dim, dropout=0.2):
+        """
+        Initialize the DenseLayer.
+
+        Parameters:
+            in_dim (int): The number of input features.
+            out_dim (int): The number of output features.
+            dropout (float, optional): The dropout rate for regularization. Default is 0.2.
+        """
         super(DenseLayer, self).__init__()
         layers = [nn.Linear(in_dim, out_dim), nn.ReLU(), nn.Dropout(dropout)]
         self.fc = nn.Sequential(*layers)
 
     def forward(self, x):
+        """
+        Perform the forward pass.
+
+        Parameters:
+            x (torch.Tensor): The input tensor.
+
+        Returns:
+            torch.Tensor: The output tensor after applying the dense layer.
+        """
         return self.fc(x)

--- a/src/layers/embedding_layer.py
+++ b/src/layers/embedding_layer.py
@@ -1,0 +1,15 @@
+import torch
+import torch.nn as nn
+
+
+class EmbeddingLayer(nn.Module):
+    def __init__(self, num_features, embedding_dim):
+        super(EmbeddingLayer, self).__init__()
+        self.embeddings = nn.ModuleList(
+            [nn.Embedding(input_dim, embedding_dim) for input_dim in num_features]
+        )
+
+    def forward(self, x):
+        return torch.cat(
+            [self.embeddings[i](x[:, i]) for i in range(len(self.embeddings))], dim=1
+        )

--- a/src/layers/embedding_layer.py
+++ b/src/layers/embedding_layer.py
@@ -3,13 +3,38 @@ import torch.nn as nn
 
 
 class EmbeddingLayer(nn.Module):
+    """
+    An embedding layer.
+    """
+
     def __init__(self, num_features, embedding_dim):
+        """
+        Initialize the EmbeddingLayer.
+
+        Parameters:
+            num_features (list[int]): A list where each element represents the size
+                                       of the vocabulary for a categorical feature.
+            embedding_dim (int): The dimension of the embedding vector for each feature.
+        """
         super(EmbeddingLayer, self).__init__()
         self.embeddings = nn.ModuleList(
             [nn.Embedding(input_dim, embedding_dim) for input_dim in num_features]
         )
 
     def forward(self, x):
+        """
+        Perform the forward pass.
+
+        Embeds each categorical feature and concatenates the embeddings.
+
+        Parameters:
+            x (torch.Tensor): A tensor of categorical feature indices with shape
+                              (batch_size, num_features).
+
+        Returns:
+            torch.Tensor: A concatenated tensor of embeddings with shape
+                          (batch_size, num_features * embedding_dim).
+        """
         return torch.cat(
             [self.embeddings[i](x[:, i]) for i in range(len(self.embeddings))], dim=1
         )

--- a/src/layers/interaction_layer.py
+++ b/src/layers/interaction_layer.py
@@ -3,12 +3,31 @@ import torch.nn as nn
 
 
 class FMInteractionLayer(nn.Module):
+    """
+    Factorization Machine (FM) Interaction Layer for modeling feature interactions.
+    """
+
     def __init__(self, input_dim):
+        """
+        Initialize the FMInteractionLayer.
+
+        Parameters:
+            input_dim (int): The number of input features.
+        """
         super(FMInteractionLayer, self).__init__()
 
         self.first_order = nn.Linear(input_dim, 1)
 
     def forward(self, x):
+        """
+        Perform the forward pass.
+
+        Parameters:
+            x (torch.Tensor): Input tensor of shape (batch_size, input_dim).
+
+        Returns:
+            tuple: First-order interactions (torch.Tensor) and second-order interactions (torch.Tensor).
+        """
         first_order = self.first_order(x)
         second_order = torch.sum(x, dim=1, keepdim=True)
 
@@ -16,7 +35,18 @@ class FMInteractionLayer(nn.Module):
 
 
 class CrossInteractionLayer(nn.Module):
+    """
+    Cross Interaction Layer for feature crossing.
+    """
+
     def __init__(self, input_dim, num_layers):
+        """
+        Initialize the CrossInteractionLayer.
+
+        Parameters:
+            input_dim (int): The number of input features.
+            num_layers (int): The number of cross-interaction layers.
+        """
         super(CrossInteractionLayer, self).__init__()
 
         self.layers = nn.ModuleList(
@@ -30,6 +60,15 @@ class CrossInteractionLayer(nn.Module):
         )
 
     def forward(self, x):
+        """
+        Perform the forward pass.
+
+        Parameters:
+            x (torch.Tensor): Input tensor of shape (batch_size, input_dim).
+
+        Returns:
+            torch.Tensor: The output tensor after applying cross-interaction layers.
+        """
         for i, layer in enumerate(self.layers):
             x = layer(x * self.weight[i]) + self.bias[i] + x
         return x

--- a/src/layers/interaction_layer.py
+++ b/src/layers/interaction_layer.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+
+
+class FMInteractionLayer(nn.Module):
+    def __init__(self, input_dim):
+        super(FMInteractionLayer, self).__init__()
+
+        self.first_order = nn.Linear(input_dim, 1)
+
+    def forward(self, x):
+        first_order = self.first_order(x)
+        second_order = torch.sum(x, dim=1, keepdim=True)
+
+        return first_order, second_order
+
+
+class CrossInteractionLayer(nn.Module):
+    def __init__(self, input_dim, num_layers):
+        super(CrossInteractionLayer, self).__init__()
+
+        self.layers = nn.ModuleList(
+            [nn.Linear(input_dim, input_dim) for _ in range(num_layers)]
+        )
+        self.weight = nn.ParameterList(
+            [nn.Parameter(torch.randn(input_dim)) for _ in range(num_layers)]
+        )
+        self.bias = nn.ParameterList(
+            [nn.Parameter(torch.zeros(1)) for _ in range(num_layers)]
+        )
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = layer(x * self.weight[i]) + self.bias[i] + x
+        return x

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,6 @@
 from .base_model import BaseCTRModel
-from lgbm import LightGBMModel
+from .lgbm import LightGBMModel
 from .deepfm import DeepFM
 from .dcn_v2 import DCNv2
 
-__all__ = ["BaseCTRModel", "DeepFM", "DCNv2"]
+__all__ = ["BaseCTRModel", "DeepFM", "DCNv2", "LightGBMModel"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,6 @@
+from .base_model import BaseCTRModel
+from lgbm import LightGBMModel
+from .deepfm import DeepFM
+from .dcn_v2 import DCNv2
+
+__all__ = ["BaseCTRModel", "DeepFM", "DCNv2"]

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+from src.layers.embedding_layer import EmbeddingLayer
+from src.layers.dense_layer import DenseLayer
+
+
+class BaseCTRModel(nn.Module):
+    def __init__(
+        self, num_numeric, categorical_dims, embedding_dim, hidden_dims, dropout
+    ):
+        super(BaseCTRModel, self).__init__()
+        self.embeddings = EmbeddingLayer(categorical_dims, embedding_dim)
+
+        # Deep Network
+        input_dim = num_numeric + len(categorical_dims) * embedding_dim
+        self.deep_layers = nn.Sequential(
+            DenseLayer(input_dim, hidden_dims[0], dropout),
+            DenseLayer(hidden_dims[0], hidden_dims[1], dropout),
+            nn.Linear(hidden_dims[1], 1)            
+        )
+    
+    def forward_embeddings(self, numeric, categorical):
+        # Embedding Lookup
+        categorical_embeddings = self.embeddings.forward(categorical)
+        return torch.cat([numeric, categorical_embeddings], dim=1)

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -6,13 +6,26 @@ from src.layers.dense_layer import DenseLayer
 
 
 class BaseCTRModel(nn.Module):
+    """
+    A base model for Click-Through Rate (CTR) prediction using deep learning.
+    """
+
     def __init__(
         self, num_numeric, categorical_dims, embedding_dim, hidden_dims, dropout
     ):
+        """
+        Initialize the BaseCTRModel.
+        
+        Parameters:
+            num_numeric (int): The number of numeric features.
+            categorical_dims (list[int]): A list containing the sizes of categorical feature dimensions.
+            embedding_dim (int): The dimension of the embedding vectors for categorical features.
+            hidden_dims (list[int]): A list containing the sizes of hidden layers in the deep network.
+            dropout (float): The dropout rate for regularization in the dense layers.
+        """
         super(BaseCTRModel, self).__init__()
         self.embeddings = EmbeddingLayer(categorical_dims, embedding_dim)
 
-        # Deep Network
         input_dim = num_numeric + len(categorical_dims) * embedding_dim
         self.deep_layers = nn.Sequential(
             DenseLayer(input_dim, hidden_dims[0], dropout),
@@ -21,6 +34,15 @@ class BaseCTRModel(nn.Module):
         )
     
     def forward_embeddings(self, numeric, categorical):
-        # Embedding Lookup
+        """
+        Forward pass for embeddings.
+
+        Parameters:
+            numeric (torch.Tensor): A tensor of numeric features.
+            categorical (torch.Tensor): A tensor of categorical feature indices.
+
+        Returns:
+            torch.Tensor: A concatenated tensor of numeric and embedded categorical features.
+        """
         categorical_embeddings = self.embeddings.forward(categorical)
         return torch.cat([numeric, categorical_embeddings], dim=1)

--- a/src/models/dcn_v2.py
+++ b/src/models/dcn_v2.py
@@ -1,0 +1,29 @@
+import torch
+import torch.nn as nn
+
+from src.models.base_model import BaseCTRModel
+from src.layers.interaction_layer import CrossInteractionLayer
+
+
+class DCNv2(BaseCTRModel):
+    def __init__(self, num_numeric, categorical_dims, embedding_dim, deep_dims, num_cross_layers, dropout):
+        super(DCNv2, self).__init__(num_numeric, categorical_dims, embedding_dim, deep_dims, dropout)
+
+        # Cross Network
+        cross_input_dim = num_numeric + len(categorical_dims) * embedding_dim
+        self.cross_network = CrossInteractionLayer(cross_input_dim, num_cross_layers)
+
+    def forward(self, numeric, categorical):
+        # Common Embedding and Feature Concatenation
+        x = self.forward_embeddings(numeric, categorical)
+
+        # Cross Network
+        cross_x = self.cross_network.forward(x)
+
+        # Deep Part
+        deep_output = self.deep_layers(x)
+
+        # Combine Cross and Deep outputs
+        output = torch.sigmoid(cross_x.sum(dim=1) + deep_output.squeeze(1))
+        
+        return output

--- a/src/models/dcn_v2.py
+++ b/src/models/dcn_v2.py
@@ -6,7 +6,22 @@ from src.layers.interaction_layer import CrossInteractionLayer
 
 
 class DCNv2(BaseCTRModel):
+    """
+    A deep and cross network (DCNv2) for Click-Through Rate (CTR) prediction.
+    """
+    
     def __init__(self, num_numeric, categorical_dims, embedding_dim, deep_dims, num_cross_layers, dropout):
+        """
+        Initialize the DCNv2 model.
+
+        Parameters:
+            num_numeric (int): The number of numeric features.
+            categorical_dims (list[int]): A list containing the sizes of categorical feature dimensions.
+            embedding_dim (int): The dimension of the embedding vectors for categorical features.
+            deep_dims (list[int]): A list containing the sizes of hidden layers in the deep network.
+            num_cross_layers (int): The number of cross-interaction layers in the Cross Network.
+            dropout (float): The dropout rate for regularization in the deep layers.
+        """
         super(DCNv2, self).__init__(num_numeric, categorical_dims, embedding_dim, deep_dims, dropout)
 
         # Cross Network
@@ -14,6 +29,16 @@ class DCNv2(BaseCTRModel):
         self.cross_network = CrossInteractionLayer(cross_input_dim, num_cross_layers)
 
     def forward(self, numeric, categorical):
+        """
+        Forward pass for the DCNv2 model.
+
+        Parameters:
+            numeric (torch.Tensor): A tensor of numeric features.
+            categorical (torch.Tensor): A tensor of categorical feature indices.
+
+        Returns:
+            torch.Tensor: A tensor containing the predicted probabilities.
+        """
         # Common Embedding and Feature Concatenation
         x = self.forward_embeddings(numeric, categorical)
 

--- a/src/models/deepfm.py
+++ b/src/models/deepfm.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+
+from src.models.base_model import BaseCTRModel
+from src.layers.interaction_layer import FMInteractionLayer
+from src.utils.load import load_yaml
+
+
+
+
+class DeepFM(BaseCTRModel):
+    def __init__(self, num_numeric, categorical_dims, embedding_dim, deep_dims, dropout):
+        super(DeepFM, self).__init__(num_numeric, categorical_dims, embedding_dim, deep_dims, dropout)
+
+        # FM Part (First-order and Second-order interactions)
+        fm_input_dim = num_numeric + len(categorical_dims) * embedding_dim
+        self.fm_network = FMInteractionLayer(fm_input_dim)
+
+    def forward(self, numeric, categorical):
+        # Common Embedding and Feature Concatenation
+        x = self.forward_embeddings(numeric, categorical)
+
+        # FM Part
+        fm_first_order, fm_second_order = self.fm_network.forward(x)
+
+        # Deep Part
+        deep_output = self.deep_layers(x)
+
+        # Combine FM and Deep outputs
+        output = fm_first_order + fm_second_order + deep_output
+        return torch.sigmoid(output).squeeze(1)

--- a/src/models/deepfm.py
+++ b/src/models/deepfm.py
@@ -9,7 +9,21 @@ from src.utils.load import load_yaml
 
 
 class DeepFM(BaseCTRModel):
+    """
+    A DeepFM model for Click-Through Rate (CTR) prediction.
+    """
+
     def __init__(self, num_numeric, categorical_dims, embedding_dim, deep_dims, dropout):
+        """
+        Initialize the DeepFM model.
+
+        Parameters:
+            num_numeric (int): The number of numeric features.
+            categorical_dims (list[int]): A list containing the sizes of categorical feature dimensions.
+            embedding_dim (int): The dimension of the embedding vectors for categorical features.
+            deep_dims (list[int]): A list containing the sizes of hidden layers in the deep network.
+            dropout (float): The dropout rate for regularization in the deep layers.
+        """
         super(DeepFM, self).__init__(num_numeric, categorical_dims, embedding_dim, deep_dims, dropout)
 
         # FM Part (First-order and Second-order interactions)
@@ -17,6 +31,16 @@ class DeepFM(BaseCTRModel):
         self.fm_network = FMInteractionLayer(fm_input_dim)
 
     def forward(self, numeric, categorical):
+        """
+        Forward pass for the DeepFM model.
+
+        Parameters:
+            numeric (torch.Tensor): A tensor of numeric features.
+            categorical (torch.Tensor): A tensor of categorical feature indices.
+
+        Returns:
+            torch.Tensor: A tensor containing the predicted probabilities.
+        """
         # Common Embedding and Feature Concatenation
         x = self.forward_embeddings(numeric, categorical)
 

--- a/src/models/lgbm.py
+++ b/src/models/lgbm.py
@@ -1,0 +1,63 @@
+import lightgbm as lgb
+
+from sklearn.metrics import roc_auc_score
+from src.utils.load import load_yaml
+
+
+class LightGBMModel:
+    def __init__(self, params=None):
+        self.conf = load_yaml()['model']['LGBM']
+        self.params = {
+            'objective': self.conf['objective'],
+            'metric': self.conf['metric'],
+            'boosting_type': self.conf['boosting_type'],
+            'learning_rate': self.conf['learning_rate'],
+            'num_leaves': self.conf['num_leaves'],
+            'max_depth': self.conf['max_depth'],
+            'min_data_in_leaf': self.conf['min_data_in_leaf'],
+            'feature_fraction': self.conf['feature_fraction'],
+            'bagging_fraction': self.conf['bagging_fraction'],
+            'bagging_freq': self.conf['bagging_freq'],
+            'verbose': self.conf['verbose'],
+            'seed': self.conf['seed']
+        }
+        self.model = None
+
+    def fit(
+        self,
+        X_train,
+        X_test,
+        y_train,
+        y_test,
+        categorical_features
+    ):
+
+        train_data = lgb.Dataset(X_train, label=y_train, categorical_feature=categorical_features)
+        test_data = lgb.Dataset(X_test, label=y_test, categorical_feature=categorical_features, reference=train_data)
+
+        self.model = lgb.train(
+            self.params,
+            train_data,
+            valid_sets=[train_data, test_data],
+            num_boost_round=self.conf['num_boost_round'],
+            callbacks=[
+                lgb.early_stopping(stopping_rounds=self.conf['early_stopping_rounds'])
+            ]
+        )
+
+    def predict(self, X):
+        if not self.model:
+            raise ValueError("Model has not been trained yet. Call `fit` first.")
+        return self.model.predict(X)
+
+    def evaluate(self, X, y):
+        y_pred = self.predict(X)
+        return roc_auc_score(y, y_pred)
+
+    def save_model(self, path):
+        if not self.model:
+            raise ValueError("Model has not been trained yet. Call `fit` first.")
+        self.model.save_model(path)
+
+    def load_model(self, path):
+        self.model = lgb.Booster(model_file=path)

--- a/src/models/lgbm.py
+++ b/src/models/lgbm.py
@@ -5,7 +5,17 @@ from src.utils.load import load_yaml
 
 
 class LightGBMModel:
+    """
+    A wrapper class of LightGBM model for Click-Through Rate (CTR) prediction.
+    """
+
     def __init__(self, params=None):
+        """
+        Initialize the LightGBMModel.
+
+        Parameters:
+            params (dict, optional): Custom LightGBM parameters. If None, default parameters are loaded from a YAML file.
+        """
         self.conf = load_yaml()['model']['LGBM']
         self.params = {
             'objective': self.conf['objective'],
@@ -31,7 +41,16 @@ class LightGBMModel:
         y_test,
         categorical_features
     ):
+        """
+        Train the LightGBM model on the provided training and testing datasets.
 
+        Parameters:
+            X_train (pd.DataFrame): The training feature set.
+            X_test (pd.DataFrame): The testing feature set.
+            y_train (pd.Series): The training target labels.
+            y_test (pd.Series): The testing target labels.
+            categorical_features (list): List of categorical feature names.
+        """
         train_data = lgb.Dataset(X_train, label=y_train, categorical_feature=categorical_features)
         test_data = lgb.Dataset(X_test, label=y_test, categorical_feature=categorical_features, reference=train_data)
 
@@ -46,18 +65,55 @@ class LightGBMModel:
         )
 
     def predict(self, X):
+        """
+        Predict target values for the given input features.
+
+        Parameters:
+            X (pd.DataFrame): The input feature set.
+
+        Returns:
+            np.ndarray: Predicted values.
+
+        Raises:
+            ValueError: If the model has not been trained yet.
+        """
         if not self.model:
             raise ValueError("Model has not been trained yet. Call `fit` first.")
         return self.model.predict(X)
 
     def evaluate(self, X, y):
+        """
+        Evaluate the model using the ROC-AUC score.
+
+        Parameters:
+            X (pd.DataFrame): The input feature set.
+            y (pd.Series): The true target labels.
+
+        Returns:
+            float: The ROC-AUC score of the model.
+        """
         y_pred = self.predict(X)
         return roc_auc_score(y, y_pred)
 
     def save_model(self, path):
+        """
+        Save the trained LightGBM model to a file.
+
+        Parameters:
+            path (str): Path where the model should be saved.
+
+        Raises:
+            ValueError: If the model has not been trained yet.
+        """
         if not self.model:
             raise ValueError("Model has not been trained yet. Call `fit` first.")
         self.model.save_model(path)
 
     def load_model(self, path):
+        """
+        Load a LightGBM model from a file.
+
+        Parameters:
+            path (str): Path to the saved model file.
+        """
         self.model = lgb.Booster(model_file=path)

--- a/src/models/lgbm.py
+++ b/src/models/lgbm.py
@@ -16,7 +16,7 @@ class LightGBMModel:
         Parameters:
             params (dict, optional): Custom LightGBM parameters. If None, default parameters are loaded from a YAML file.
         """
-        self.conf = load_yaml()['model']['LGBM']
+        self.conf = load_yaml('lgbm')['model']['LGBM']
         self.params = {
             'objective': self.conf['objective'],
             'metric': self.conf['metric'],

--- a/src/preprocessing/preprocess.py
+++ b/src/preprocessing/preprocess.py
@@ -1,0 +1,40 @@
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import LabelEncoder, MinMaxScaler
+
+
+def preprocess_data(data):
+    data.columns = (
+        ["Label"] + [f"I{i}" for i in range(1, 14)] + [f"C{i}" for i in range(1, 27)]
+    )
+
+    num_cols = [col for col in data.columns if col.startswith("I")]
+    cat_cols = [col for col in data.columns if col.startswith("C")]
+
+    data[num_cols] = data[num_cols].fillna(0)
+    data[cat_cols] = data[cat_cols].fillna("missing")
+
+    data[num_cols] = MinMaxScaler().fit_transform(data[num_cols])
+    for col in cat_cols:
+        data[col] = LabelEncoder().fit_transform(data[col].astype(str))
+
+    features = num_cols + cat_cols
+
+    X = data[features]
+    y = data["Label"]
+
+    return X, y, num_cols, cat_cols
+
+
+def split_data(X, y, num_cols, cat_cols, split_num_cat=True):
+    if split_num_cat:
+        X_train_num, X_test_num, X_train_cat, X_test_cat, y_train, y_test = (
+            train_test_split(
+                X[num_cols], X[cat_cols], y, test_size=0.2, random_state=42
+            )
+        )
+        return X_train_num, X_test_num, X_train_cat, X_test_cat, y_train, y_test
+    else:
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=42
+        )
+        return X_train, X_test, y_train, y_test

--- a/src/preprocessing/preprocess.py
+++ b/src/preprocessing/preprocess.py
@@ -3,6 +3,20 @@ from sklearn.preprocessing import LabelEncoder, MinMaxScaler
 
 
 def preprocess_data(data):
+    """
+    Preprocess the dataset by handling missing values, scaling numeric features,
+    and encoding categorical features.
+
+    Parameters:
+        data (pd.DataFrame): The input raw dataset.
+
+    Returns:
+        tuple:
+            - X (pd.DataFrame): The preprocessed features.
+            - y (pd.Series): The target labels.
+            - num_cols (list): List of numeric column names.
+            - cat_cols (list): List of categorical column names.
+    """
     data.columns = (
         ["Label"] + [f"I{i}" for i in range(1, 14)] + [f"C{i}" for i in range(1, 27)]
     )
@@ -26,6 +40,32 @@ def preprocess_data(data):
 
 
 def split_data(X, y, num_cols, cat_cols, split_num_cat=True):
+    """
+    Split the dataset into training and testing sets.
+
+    Parameters:
+        X (pd.DataFrame): The preprocessed feature set.
+        y (pd.Series): The target labels.
+        num_cols (list): List of numeric column names.
+        cat_cols (list): List of categorical column names.
+        split_num_cat (bool, optional): Whether to split numeric and categorical features separately.
+                                         Default is True.
+
+    Returns:
+        tuple: Training and testing sets.
+            If split_num_cat is True:
+                - X_train_num (pd.DataFrame): Training numeric features.
+                - X_test_num (pd.DataFrame): Testing numeric features.
+                - X_train_cat (pd.DataFrame): Training categorical features.
+                - X_test_cat (pd.DataFrame): Testing categorical features.
+                - y_train (pd.Series): Training labels.
+                - y_test (pd.Series): Testing labels.
+            If split_num_cat is False:
+                - X_train (pd.DataFrame): Training features.
+                - X_test (pd.DataFrame): Testing features.
+                - y_train (pd.Series): Training labels.
+                - y_test (pd.Series): Testing labels.
+    """
     if split_num_cat:
         X_train_num, X_test_num, X_train_cat, X_test_cat, y_train, y_test = (
             train_test_split(

--- a/src/trainers/eval.py
+++ b/src/trainers/eval.py
@@ -5,15 +5,45 @@ from sklearn.metrics import log_loss, accuracy_score
 
 
 def compute_log_loss(y_true, y_pred):
+    """
+    Compute the Log Loss for the given true and predicted values.
+
+    Parameters:
+        y_true (array-like): True binary labels.
+        y_pred (array-like): Predicted probabilities.
+
+    Returns:
+        float: Log Loss value.
+    """
     return log_loss(y_true, y_pred)
 
 
 def compute_accuracy(y_true, y_pred):
+    """
+    Compute the accuracy for the given true and predicted values.
+
+    Parameters:
+        y_true (array-like): True binary labels.
+        y_pred (array-like): Predicted probabilities.
+
+    Returns:
+        float: Accuracy score.
+    """
     y_pred_binary = (y_pred > 0.5).astype(int)
     return accuracy_score(y_true, y_pred_binary)
 
 
 def evaluate_dl_model(model, dataloader):
+    """
+    Evaluate a deep learning model on the given dataloader.
+
+    Parameters:
+        model (torch.nn.Module): The deep learning model to evaluate.
+        dataloader (torch.utils.data.DataLoader): Dataloader for evaluation data.
+
+    Returns:
+        tuple: Log Loss and Accuracy of the model on the evaluation data.
+    """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     model.eval()
@@ -37,6 +67,17 @@ def evaluate_dl_model(model, dataloader):
 
 
 def evaluate_lgbm_model(model, data, labels):
+    """
+    Evaluate a LightGBM model on the given dataset.
+
+    Parameters:
+        model (lightgbm.Booster): The LightGBM model to evaluate.
+        data (pd.DataFrame): Feature data for evaluation.
+        labels (pd.Series): True binary labels.
+
+    Returns:
+        tuple: Log Loss and Accuracy of the model on the evaluation data.
+    """
     preds = model.predict(data)
 
     log_loss = compute_log_loss(labels, preds)

--- a/src/trainers/eval.py
+++ b/src/trainers/eval.py
@@ -1,0 +1,46 @@
+import torch
+import numpy as np
+
+from sklearn.metrics import log_loss, accuracy_score
+
+
+def compute_log_loss(y_true, y_pred):
+    return log_loss(y_true, y_pred)
+
+
+def compute_accuracy(y_true, y_pred):
+    y_pred_binary = (y_pred > 0.5).astype(int)
+    return accuracy_score(y_true, y_pred_binary)
+
+
+def evaluate_dl_model(model, dataloader):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model.eval()
+    preds, labels = [], []
+
+    with torch.no_grad():
+        for numeric, categorical, label in dataloader:
+            numeric = numeric.to(device)
+            categorical = categorical.to(device)
+            label = label.to(device)
+
+            outputs = model(numeric, categorical)
+            preds.extend(outputs.cpu().numpy())
+            labels.extend(label.cpu().numpy())
+
+    log_loss = compute_log_loss(np.array(labels), np.array(preds))
+    accuracy = compute_accuracy(np.array(labels), np.array(preds))
+
+    print(f"Log Loss: {log_loss:.4f}, Accuracy: {accuracy:.4f}")
+    return log_loss, accuracy
+
+
+def evaluate_lgbm_model(model, data, labels):
+    preds = model.predict(data)
+
+    log_loss = compute_log_loss(labels, preds)
+    accuracy = compute_accuracy(labels, preds)
+
+    print(f"Log Loss: {log_loss:.4f}, Accuracy: {accuracy:.4f}")
+    return log_loss, accuracy

--- a/src/trainers/train.py
+++ b/src/trainers/train.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+def train_dl_model(model, train_loader, test_loader, epochs):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    criterion = nn.BCELoss()
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+
+    for epoch in range(epochs):
+        model.train()
+        train_loss = 0.0
+
+        for numeric, categorical, labels in train_loader:
+            numeric, categorical, labels = (
+                numeric.to(device),
+                categorical.to(device),
+                labels.to(device),
+            )
+
+            optimizer.zero_grad()
+            outputs = model(numeric, categorical)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            train_loss += loss.item()
+
+        # Evaluation
+        model.eval()
+        test_loss = 0.0
+        with torch.no_grad():
+            for numeric, categorical, labels in test_loader:
+                numeric, categorical, labels = (
+                    numeric.to(device),
+                    categorical.to(device),
+                    labels.to(device),
+                )
+                outputs = model(numeric, categorical)
+                loss = criterion(outputs, labels)
+                test_loss += loss.item()
+
+        print(
+            f"Epoch {epoch + 1}/{epochs}, Train Loss: {train_loss / len(train_loader):.4f}, Test Loss: {test_loss / len(test_loader):.4f}"
+        )
+
+
+def train_lgbm_model(model, X_train, y_train, X_val, y_val):
+    model.fit(X_train, y_train, X_val, y_val)
+    auc_score = model.evaluate(X_val, y_val)
+    print(f"LightGBM Validation AUC: {auc_score:.4f}")

--- a/src/trainers/train.py
+++ b/src/trainers/train.py
@@ -4,6 +4,15 @@ import torch.optim as optim
 
 
 def train_dl_model(model, train_loader, test_loader, epochs):
+    """
+    Train a deep learning model.
+
+    Parameters:
+        model (torch.nn.Module): The deep learning model to train.
+        train_loader (torch.utils.data.DataLoader): Dataloader for the training data.
+        test_loader (torch.utils.data.DataLoader): Dataloader for the testing/validation data.
+        epochs (int): The number of training epochs.
+    """
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     criterion = nn.BCELoss()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
@@ -47,6 +56,16 @@ def train_dl_model(model, train_loader, test_loader, epochs):
 
 
 def train_lgbm_model(model, X_train, y_train, X_val, y_val):
+    """
+    Train a LightGBM model and evaluate it on the validation data.
+
+    Parameters:
+        model (lightgbm.Booster): The LightGBM model to train.
+        X_train (pd.DataFrame): Training feature data.
+        y_train (pd.Series): Training target labels.
+        X_val (pd.DataFrame): Validation feature data.
+        y_val (pd.Series): Validation target labels.
+    """
     model.fit(X_train, y_train, X_val, y_val)
     auc_score = model.evaluate(X_val, y_val)
     print(f"LightGBM Validation AUC: {auc_score:.4f}")

--- a/src/utils/load.py
+++ b/src/utils/load.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import yaml
+
+
+def load_yaml():
+    file_path = "/Users/euyeom/Desktop/Gigi/repo/ctr-pred-sys/configs/config.yaml"
+    with open(file_path, "r") as file:
+        data = yaml.safe_load(file)
+    return data
+
+
+def load_data(path):
+    data = pd.read_csv(path, sep="\t", header=None)
+    return data

--- a/src/utils/load.py
+++ b/src/utils/load.py
@@ -2,13 +2,30 @@ import pandas as pd
 import yaml
 
 
-def load_yaml():
-    file_path = "/Users/euyeom/Desktop/Gigi/repo/ctr-pred-sys/configs/config.yaml"
-    with open(file_path, "r") as file:
+def load_yaml(path):
+    """
+    Load a YAML file and return its contents.
+
+    Parameters:
+        path (str): The file path to the YAML file.
+
+    Returns:
+        dict: A dictionary containing the contents of the YAML file.
+    """
+    with open(path, "r") as file:
         data = yaml.safe_load(file)
     return data
 
 
 def load_data(path):
+    """
+    Load a csv file into a Pandas DataFrame.
+
+    Parameters:
+        path (str): The file path to the csv file.
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the contents of the csv file.
+    """
     data = pd.read_csv(path, sep="\t", header=None)
     return data

--- a/src/utils/load.py
+++ b/src/utils/load.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import yaml
+import os
 
-
-def load_yaml(path):
+def load_yaml(conf_name):
     """
     Load a YAML file and return its contents.
 
@@ -12,10 +12,13 @@ def load_yaml(path):
     Returns:
         dict: A dictionary containing the contents of the YAML file.
     """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(base_dir, f"configs/{conf_name}.yaml")
+
     with open(path, "r") as file:
         data = yaml.safe_load(file)
     return data
-
+d
 
 def load_data(path):
     """

--- a/src/utils/load.py
+++ b/src/utils/load.py
@@ -18,7 +18,6 @@ def load_yaml(conf_name):
     with open(path, "r") as file:
         data = yaml.safe_load(file)
     return data
-d
 
 def load_data(path):
     """


### PR DESCRIPTION
- small dataset에 대해서 CTR Prediction을 진행하는 3개의 모델 개발
      - LightGBM
      - DeepFM
      - DCNv2
- 다음의 코드 개발
      - preprocess
      - dataset
      - dataloader
      - layers
      - models
      - training
      - evaluation
- DeepFM, DCNv2의 경우 Baseline 모델을 상속하여 공통된 기능은 공통 Layer에서 구현하도록 분리
- yaml 기반의 Config 파일 적용